### PR TITLE
fix: avoid code examples in default prompt

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -67,7 +67,7 @@ const buildDefaultPrompt = (context: IssueContext): string => {
     "If the specification is insufficient, ask clarifying questions.",
     "If the specification is sufficient, output the completed spec.",
     "Do not include code examples, snippets, or pseudo-code.",
-    "Describe requirements, behavior, and what needs to change in implementation-agnostic language.",
+    "Describe requirements, behavior, and required functional changes using implementation-agnostic language.",
     "",
     "Return JSON only.",
     "Format:",


### PR DESCRIPTION
## Summary
- instruct the agent to avoid code examples in specs
- emphasize implementation-agnostic requirements

## Testing
- tsc --noEmit

Closes #7